### PR TITLE
Travis Integration for Indra in DevOps Fall 2021 Slack Channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ notifications:
     slack:
         rooms:
             - indras-net:$SLACK_TOKEN
-            - devopsfall2021:$devopsfall2021#travis
+            - devopsfall2021:$SLACK_TOKEN_DEVOPS
     email:
         recipients:
             - gcallah@mac.com


### PR DESCRIPTION
Travis Integration with DevOps2021 Slack Channel was broken
This Patch tries to fix it